### PR TITLE
Revert update of `@types/vscode` package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       all:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@tsconfig/node18": "^18.2.4",
     "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.10.1",
-    "@types/vscode": "^1.95.0",
+    "@types/vscode": "^1.84.2",
     "@typescript-eslint/eslint-plugin": "^8.16.0",
     "@vscode/test-electron": "^2.4.1",
     "esbuild": "^0.24.0",


### PR DESCRIPTION
`vsce` requires that `@types/vscode` version matches Code engine version requirement.