### PR TITLE
Handle CairoLS >=2.9.1 in env filter

### DIFF
--- a/src/cairols.ts
+++ b/src/cairols.ts
@@ -226,7 +226,12 @@ function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
 
 function buildEnvFilter(ctx: Context): string {
   const level = convertVscodeLogLevelToRust(ctx.log.logLevel);
-  return level ? `cairo_lang_language_server=${level}` : "";
+  return level
+    ? // CairoLS >= 2.9.1 is written in `cairo_language_server` crate,
+      // while earlier versions are `cairo_lang_language_server`.
+      // We want to support both for a while.
+      `cairo_language_server=${level},cairo_lang_language_server=${level}`
+    : "";
 }
 
 function convertVscodeLogLevelToRust(logLevel: vscode.LogLevel): string | null {


### PR DESCRIPTION
### Pull Request Description

**Title:** Handle CairoLS >=2.9.1 in env filter

**Description:**
This pull request addresses the compatibility of the environment filter with CairoLS version 2.9.1 and above. The changes ensure that the application can correctly handle the new features and updates introduced in these versions, improving overall functionality and stability.

**Changes Made:**
- Updated the environment filter logic to accommodate CairoLS version 2.9.1 and later.
- Ensured backward compatibility with earlier versions of CairoLS.

This enhancement is crucial for users who have upgraded to CairoLS 2.9.1 or higher, as it ensures that the environment filter continues to operate as expected without any disruptions. 

Please review the changes and provide feedback. Thank you!