### PR TITLE
Remove `afterEach` in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       matrix:
         scarb: [disabled, "2.7.1", "2.8.5", "2.9.1"]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -53,6 +54,9 @@ jobs:
       - run: npm ci
       - run: npm run compile-test
       - run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run ui-test
+        if: ${{ matrix.os == 'ubuntu-latest'}}
+      - run: npm run ui-test
+        if: ${{ matrix.os != 'ubuntu-latest'}}
   test-ui:
     if: ${{ always() }}
     needs: test-ui-parametrized

--- a/ui-test/expandMacro.ts
+++ b/ui-test/expandMacro.ts
@@ -18,10 +18,6 @@ describe("Expand macro test", function () {
     await VSBrowser.instance.openResources(path.join("ui-test", "fixtures", "expand_macro"));
   });
 
-  afterEach(async function () {
-    await editorView.closeAllEditors();
-  });
-
   it("checks if macro correctly expands", async function () {
     assertExpandAt(
       editorView,

--- a/ui-test/statusBar.ts
+++ b/ui-test/statusBar.ts
@@ -1,4 +1,4 @@
-import { EditorView, StatusBar, VSBrowser, WebElement, Workbench } from "vscode-extension-tester";
+import { StatusBar, VSBrowser, WebElement, Workbench } from "vscode-extension-tester";
 import { expect } from "chai";
 import { isScarbAvailable } from "../test-support/scarb";
 import * as path from "path";
@@ -8,10 +8,6 @@ describe("Status bar", function () {
 
   before(async function () {
     await VSBrowser.instance.openResources(path.join("ui-test", "fixtures", "empty"));
-  });
-
-  afterEach(async function () {
-    await new EditorView().closeAllEditors();
   });
 
   it("Displays Cairo toolchain version", async function () {


### PR DESCRIPTION
This is actually useless, nondeterministic and can lead to failing tests.

---

**Stack**:
- #45 ⬅
- #35
- #34


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*