### PR TITLE
Add an option to enable the linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,12 @@
             "default": false,
             "description": "Enable support for procedural macros. This feature is in active development and may not work flawlessly yet!",
             "scope": "window"
+          },
+          "cairo1.enableLinter": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable cairo-lint during analysis.",
+            "scope": "window"
           }
         }
       }


### PR DESCRIPTION
Related to [#157](https://github.com/software-mansion/cairols/issues/157)

## Changes
* Extension settings contain a new option, "Enable linter"
* The option controls whether `cairo-lint` is active during the analysis
* The corresponding changes in `cairols` are introduced in https://github.com/software-mansion/cairols/pull/285