### PR TITLE
Enable procedural macros by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
           },
           "cairo1.enableProcMacros": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Enable support for procedural macros. This feature is in active development and may not work flawlessly yet!",
             "scope": "window"
           },


### PR DESCRIPTION
## Changes
* The `Enable proc macros` option is on by default, because of the changes from https://github.com/software-mansion/cairols/pull/210