### PR TITLE
Notify about errors and warnings via status bar

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -12,12 +12,19 @@ const CAIRO_STATUS_BAR_TXT = "Cairo";
 const SPINNER = "$(loading~spin)";
 const CAIRO_STATUS_BAR_SPINNING = `${CAIRO_STATUS_BAR_TXT} ${SPINNER}`;
 
+export type ServerStatus =
+  | { health: "ok" }
+  | { health: "warning"; message: string }
+  | { health: "error"; message: string };
+
 export class StatusBar {
   private readonly statusBarItem: vscode.StatusBarItem;
   private client?: lc.LanguageClient | undefined;
+  private status: ServerStatus;
 
   constructor(private readonly context: Context) {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    this.status = { health: "ok" };
 
     this.context.extension.subscriptions.push(this.statusBarItem);
   }
@@ -82,38 +89,62 @@ export class StatusBar {
   private async initializeStatusBarItem(): Promise<void> {
     this.statusBarItem.command = CAIRO_STATUS_BAR_COMMAND;
     this.statusBarItem.text = CAIRO_STATUS_BAR_TXT;
-    this.statusBarItem.tooltip = "Cairo Language";
-
-    await this.updateScarbVersion();
+    this.statusBarItem.tooltip = await this.makeTooltip();
   }
 
-  private async updateScarbVersion(): Promise<void> {
-    if (this.client) {
+  /**
+   * Returns a basic tooltip with versions of LS, Scarb, Cairo and Sierra.
+   */
+  private async makeTooltip(): Promise<vscode.MarkdownString> {
+    const tooltip = new vscode.MarkdownString("Cairo Language");
+
+    if (!this.client) {
+      return tooltip;
+    }
+
+    try {
+      const request = this.client.sendRequest(toolchainInfo);
+
+      // TODO(#50) When there is no handler for method on server it never resolves instead of failing.
+      const response = await timeout(request, 1000);
+
+      tooltip.value = `Cairo Language Server ${response.ls.version} (${response.ls.path})`;
+
+      if (response.scarb) {
+        tooltip.appendText(`\n${response.scarb.version}`);
+      }
+    } catch {
+      this.context.log.trace("Status bar: Falling back to old version resolution");
+      // TODO(#50) Remove this later.
       try {
-        const request = this.client.sendRequest(toolchainInfo);
-
-        // TODO(#50) When there is no handler for method on server it never resolves instead of failing.
-        const response = await timeout(request, 1000);
-
-        this.statusBarItem.tooltip = `Cairo Language Server ${response.ls.version} (${response.ls.path})`;
-
-        if (response.scarb) {
-          this.statusBarItem.tooltip += `\n${response.scarb.version}`;
+        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], this.context);
+        if (scarb) {
+          const version = await scarb.getVersion(this.context);
+          tooltip.appendText(`\n${version}`);
         }
-      } catch {
-        this.context.log.trace("Status bar: Falling back to old version resolution");
-        // TODO(#50) Remove this later.
-        try {
-          const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], this.context);
-          if (scarb) {
-            const version = await scarb.getVersion(this.context);
-            this.statusBarItem.tooltip = `Cairo Language\n${version}`;
-          }
-        } catch (error) {
-          this.context.log.error(`Error getting Scarb version: ${error}`);
-        }
+      } catch (error) {
+        this.context.log.error(`Error getting Scarb version: ${error}`);
       }
     }
+
+    return tooltip;
+  }
+
+  /**
+   * Updates the displayed status and refreshes the bar on the UI.
+   */
+  async setStatus(status: ServerStatus): Promise<void> {
+    this.status = status;
+    await this.update();
+  }
+
+  /**
+   * Updates the status bar by pulling the new workspace configuration
+     and sets the status of the server to "OK".
+   */
+  public async reset(): Promise<void> {
+    this.status = { health: "ok" };
+    await this.update();
   }
 
   /**
@@ -123,19 +154,39 @@ export class StatusBar {
     const config = vscode.workspace.getConfiguration("cairo1");
     const showInStatusBar = config.get<boolean>("showInStatusBar", true);
 
-    if (showInStatusBar) {
-      await this.updateScarbVersion();
-      this.showStatusBarItem();
-    } else {
-      this.hideStatusBarItem();
+    if (!showInStatusBar) {
+      this.statusBarItem.hide();
+      return;
     }
-  }
 
-  public showStatusBarItem(): void {
+    let backgroundColor = new vscode.ThemeColor("statusBar.background");
+
+    const tooltip = await this.makeTooltip();
+    tooltip.appendMarkdown("\n---\n");
+
+    const status = this.status;
+
+    switch (status.health) {
+      case "ok": {
+        tooltip.appendText("Server status: OK");
+        break;
+      }
+      case "warning": {
+        backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
+        tooltip.appendText("Server status: OK").appendText(`\nWarning: ${status.message}`);
+        this.stopSpinning();
+        break;
+      }
+      case "error": {
+        backgroundColor = new vscode.ThemeColor("statusBarItem.errorBackground");
+        tooltip.appendText(`Server status: Error\n${status.message}`);
+        this.stopSpinning();
+        break;
+      }
+    }
+
+    this.statusBarItem.backgroundColor = backgroundColor;
+    this.statusBarItem.tooltip = tooltip;
     this.statusBarItem.show();
-  }
-
-  public hideStatusBarItem(): void {
-    this.statusBarItem.hide();
   }
 }

--- a/ui-test/generic/statusBar.ts
+++ b/ui-test/generic/statusBar.ts
@@ -27,10 +27,10 @@ describe("Status bar", function () {
 
     if (isScarbAvailable) {
       expect(title).to.match(
-        /((Cairo Language Server .+ \(.+\)\n)|(Cairo Language\n))scarb .+ \(.+\)\ncairo: .+ \(.+\)\nsierra: .+/,
+        /Cairo, (Cairo Language|Cairo Language Server.+\(.+\))\n\nscarb.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/,
       );
     } else {
-      expect(title).to.be.eq("Cairo, Cairo Language");
+      expect(title).to.be.eq("Cairo, Cairo Language\n---\nServer&nbsp;status:&nbsp;OK");
     }
   });
 

--- a/ui-test/scarb/toolchainInfo.ts
+++ b/ui-test/scarb/toolchainInfo.ts
@@ -49,14 +49,21 @@ describe("Toolchain info", function () {
 
     const title = await statusBar!.getAttribute(StatusBar["locators"].StatusBar.itemTitle);
 
+    expect(title).to.match(
+      /Cairo, (Cairo Language|Cairo Language Server.+\(.+\))\n\n.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/,
+    );
+
     const matches =
-      /Cairo, (?:Cairo Language Server .+ \(.+\)\n)?Cairo Language\nscarb (.+) \(.+\)\ncairo: .+ \(.+\)\nsierra: .+/.exec(
+      /Cairo, (?:Cairo Language|Cairo Language Server.+\(.+\))\n\nscarb(.+)\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/.exec(
         title,
       );
 
     expect(matches).to.not.be.undefined;
+    expect(matches).to.not.be.null;
+    expect(matches![1]).to.not.be.undefined;
+    expect(matches![1]).to.not.be.null;
 
-    const scarbVersion = matches![1];
+    const scarbVersion = matches![1]!.replaceAll("&nbsp;", "").replaceAll("\\", "");
 
     expect(scarbVersion).to.be.eq(expectedScarbVersion);
   });


### PR DESCRIPTION
Closes #87 

## Changes
* Status bar indicates errors and warnings by changing its color
* Hover above the status bar shows the status of the language server and warnings/error messages
* Extension informs about critical, non-recoverable errors (e.g. proc macro server failure) via the status bar

## Preview
1. Status bar color (spinner spinner):
<img width="147" alt="image" src="https://github.com/user-attachments/assets/0b270ce9-4b77-4af4-a2e6-a1dec4553f51" />

2. Error information:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/3d687fa9-0277-4bd7-843b-59ea588d92f3" />