### PR TITLE
Automatically enable proc macros if Scarb version is at least `2.12`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/semver": "^7.7.0",
         "promise-timeout": "^1.3.0",
+        "semver": "^7.7.2",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -1191,6 +1193,12 @@
         "@types/node": "*",
         "@types/ws": "*"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.95.0",
@@ -5925,9 +5933,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -243,7 +243,9 @@
     "vscode": "^1.84.0"
   },
   "dependencies": {
+    "@types/semver": "^7.7.0",
     "promise-timeout": "^1.3.0",
+    "semver": "^7.7.2",
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,10 @@ export class Config {
     }
     return value;
   }
+
+  public set<K extends keyof ConfigProps>(prop: K, value: ConfigProps[K]) {
+    vscode.workspace.getConfiguration(Config.ROOT).update(prop, value);
+  }
 }
 
 function isPropWithPlaceholders(prop: keyof ConfigProps): boolean {


### PR DESCRIPTION
Closes #125

**Stack**:
- #127 ⬅
- #126


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*