### PR TITLE
Revert "Automatically enable proc macros if Scarb version is at least `2.12` (#127)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/semver": "^7.7.0",
         "promise-timeout": "^1.3.0",
-        "semver": "^7.7.2",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -1193,12 +1191,6 @@
         "@types/node": "*",
         "@types/ws": "*"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
-      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.95.0",
@@ -5933,9 +5925,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -243,9 +243,7 @@
     "vscode": "^1.84.0"
   },
   "dependencies": {
-    "@types/semver": "^7.7.0",
     "promise-timeout": "^1.3.0",
-    "semver": "^7.7.2",
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {

--- a/src/cairols.ts
+++ b/src/cairols.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { SemanticTokensFeature } from "vscode-languageclient/lib/common/semanticTokens";
-import { coerce, satisfies } from "semver";
 
 import * as lc from "vscode-languageclient/node";
 import { Context } from "./context";
@@ -50,17 +49,6 @@ export async function setupLanguageServer(ctx: Context): Promise<SetupResult | u
 
   setupEnv(run, ctx);
   ctx.log.debug(`using CairoLS: ${quoteServerExecutable(run)}`);
-
-  const scarbVersionOutput = await executables[0].scarb?.getVersion(ctx);
-  const scarbVersion = scarbVersionOutput?.match(/scarb (.+) /)?.at(1);
-
-  // Skip "rc", "dev" and "nightly" suffixes. 2.12.0-rc.0 will become 2.12.0.
-  const scarbVersionFull = coerce(scarbVersion);
-
-  // Proc macros are enabled since 2.12.0-rc.0. There is no elegant way to exclude "rc" while still including "dev" and "nightly".
-  if (satisfies(scarbVersionFull ?? "0.0.1", ">= 2.12.0")) {
-    ctx.config.set("enableProcMacros", true);
-  }
 
   const serverOptions = { run, debug: run };
   // We pass client options to maintain compability with older LS binaries.

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,10 +33,6 @@ export class Config {
     }
     return value;
   }
-
-  public set<K extends keyof ConfigProps>(prop: K, value: ConfigProps[K]) {
-    vscode.workspace.getConfiguration(Config.ROOT).update(prop, value);
-  }
 }
 
 function isPropWithPlaceholders(prop: keyof ConfigProps): boolean {


### PR DESCRIPTION
This reverts commit 82abf23b8057f7a3706619d670a3f3b10a507809.

It was just wrong - it caused the extension to override local settings file instead of changing it only when sending the config to the server.