### PR TITLE
wip

### DIFF
--- a/test-support/page-objects/cairoStatusBarItem.ts
+++ b/test-support/page-objects/cairoStatusBarItem.ts
@@ -1,4 +1,4 @@
-import { StatusBar, WebElement } from "vscode-extension-tester";
+import { StatusBar, VSBrowser, WebElement } from "vscode-extension-tester";
 
 export async function getStatusBarItem(): Promise<WebElement | undefined> {
   const items = await new StatusBar().getItems();
@@ -19,4 +19,54 @@ export async function getStatusBarItem(): Promise<WebElement | undefined> {
   }
 
   return undefined;
+}
+
+/**
+ * Waits until the Cairo status bar item exists and its title satisfies `isExpected`.
+ *
+ * The status bar item is created before the language server reports toolchain info,
+ * so its title fills up asynchronously — reading it just once races with the server
+ * startup (and with workspace reloads).
+ *
+ * Returns the last observed title even if it never satisfied `isExpected`, so that
+ * callers can assert on it and produce a readable failure message. Returns undefined
+ * if the status bar item never appeared.
+ */
+export async function getStatusBarItemTitle(
+  isExpected: (title: string) => boolean,
+  timeout: number,
+): Promise<string | undefined> {
+  let lastTitle: string | undefined;
+
+  await VSBrowser.instance.driver
+    .wait(
+      async () => {
+        const item = await getStatusBarItem();
+
+        if (!item) {
+          return false;
+        }
+
+        try {
+          // `new StatusBar().getItem("Cairo")` is broken and searches not only in title.
+          lastTitle =
+            (await item.getAttribute(StatusBar["locators"].StatusBar.itemTitle)) ?? undefined;
+        } catch {
+          // The item could have been re-rendered between finding it and reading
+          // its title, try again.
+          return false;
+        }
+
+        return lastTitle !== undefined && isExpected(lastTitle);
+      },
+      timeout,
+      undefined,
+      // Check every second.
+      1000,
+    )
+    .catch(() => {
+      // Timed out — fall through and let the caller assert on the last observed title.
+    });
+
+  return lastTitle;
 }

--- a/test-support/page-objects/settings.ts
+++ b/test-support/page-objects/settings.ts
@@ -1,0 +1,31 @@
+import { Setting, VSBrowser, Workbench } from "vscode-extension-tester";
+
+/**
+ * Opens the settings editor and finds a setting, retrying until it shows up.
+ *
+ * `SettingsEditor.findSetting` is racy: it returns undefined (or throws) when
+ * the settings editor is still opening, the search results have not settled yet,
+ * or the virtualized settings list has not rendered the requested row.
+ * Calling it once is the most common source of UI test flakiness in CI
+ * (`TypeError: Cannot read properties of undefined (reading 'setValue')`).
+ */
+export async function findSetting(title: string, category: string): Promise<Setting> {
+  const setting = await VSBrowser.instance.driver.wait(
+    async () => {
+      try {
+        const settings = await new Workbench().openSettings();
+
+        return await settings.findSetting(title, category);
+      } catch {
+        // Retry from scratch, including reopening the settings editor.
+        return undefined;
+      }
+    },
+    30000,
+    `failed to find setting: ${category} > ${title}`,
+    // Check every second.
+    1000,
+  );
+
+  return setting as Setting;
+}

--- a/test-support/page-objects/workbench.ts
+++ b/test-support/page-objects/workbench.ts
@@ -1,0 +1,27 @@
+import { VSBrowser, Workbench } from "vscode-extension-tester";
+
+/**
+ * Executes a command via the command palette, retrying on transient failures.
+ *
+ * `Workbench.executeCommand` opens the command prompt and immediately types into it.
+ * If focus is trapped in another widget (e.g. a settings editor input), the prompt
+ * may not be interactable yet and the call throws `ElementNotInteractableError`.
+ * Retry the whole sequence until it succeeds.
+ */
+export async function executeCommand(command: string): Promise<void> {
+  await VSBrowser.instance.driver.wait(
+    async () => {
+      try {
+        await new Workbench().executeCommand(command);
+
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    30000,
+    `failed to execute command: ${command}`,
+    // Check every second.
+    1000,
+  );
+}

--- a/ui-test/generic/statusBar.ts
+++ b/ui-test/generic/statusBar.ts
@@ -1,11 +1,15 @@
-import { StatusBar, VSBrowser, Workbench } from "vscode-extension-tester";
+import { VSBrowser } from "vscode-extension-tester";
 import { expect } from "chai";
 import { isScarbAvailable } from "../../test-support/scarb";
 import * as path from "path";
-import { getStatusBarItem } from "../../test-support/page-objects/cairoStatusBarItem";
+import {
+  getStatusBarItem,
+  getStatusBarItemTitle,
+} from "../../test-support/page-objects/cairoStatusBarItem";
+import { findSetting } from "../../test-support/page-objects/settings";
 
 describe("Status bar", function () {
-  this.timeout(50000);
+  this.timeout(120000);
 
   before(async function () {
     await VSBrowser.instance.openResources(path.join("ui-test", "fixtures", "empty"));
@@ -13,40 +17,42 @@ describe("Status bar", function () {
 
   it("Displays Cairo toolchain version", async function () {
     await VSBrowser.instance.waitForWorkbench();
-    const statusBar = await VSBrowser.instance.driver.wait(
-      getStatusBarItem,
-      5000,
-      "failed to obtain Cairo status bar",
-      // Check every 0.5 second.
-      500,
-    );
-
-    expect(statusBar).not.undefined;
-
-    // `new StatusBar().getItem("Cairo")` is broken and searches not only in title.
-    const title = await statusBar!.getAttribute(StatusBar["locators"].StatusBar.itemTitle);
 
     if (isScarbAvailable) {
-      expect(title).to.match(
-        /Cairo, (Cairo Language Server.+\(.+\))\n\nscarb.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/,
-      );
+      const titlePattern =
+        /Cairo, (Cairo Language Server.+\(.+\))\n\nscarb.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/;
+
+      // The title shows toolchain info only after the language server starts,
+      // so poll until it appears instead of reading it once.
+      const title = await getStatusBarItemTitle((title) => titlePattern.test(title), 60000);
+
+      expect(title).to.not.be.undefined;
+      expect(title!).to.match(titlePattern);
     } else {
-      expect(title).to.be.eq("Cairo, Cairo Language\n---\nServer&nbsp;status:&nbsp;OK");
+      const expectedTitle = "Cairo, Cairo Language\n---\nServer&nbsp;status:&nbsp;OK";
+
+      const title = await getStatusBarItemTitle((title) => title === expectedTitle, 60000);
+
+      expect(title).to.be.eq(expectedTitle);
     }
   });
 
   it("checks if status bar is disabled", async function () {
     await VSBrowser.instance.waitForWorkbench();
-    const settings = await new Workbench().openSettings();
 
-    const setting = await settings.findSetting("Show In Status Bar", "Cairo1");
+    const setting = await findSetting("Show In Status Bar", "Cairo1");
+
     await setting.setValue(false);
 
-    const statusBarIsUndefined = await VSBrowser.instance.driver.wait(async () => {
-      const statusBar = await getStatusBarItem();
+    const statusBarIsUndefined = await VSBrowser.instance.driver.wait(
+      async () => {
+        const statusBar = await getStatusBarItem();
 
-      return statusBar === undefined;
-    }, 2000);
+        return statusBar === undefined;
+      },
+      10000,
+      "Cairo status bar item is still visible after disabling it",
+    );
 
     expect(statusBarIsUndefined).to.be.true;
   });

--- a/ui-test/scarb/toolchainInfo.ts
+++ b/ui-test/scarb/toolchainInfo.ts
@@ -1,11 +1,16 @@
-import { StatusBar, VSBrowser, Workbench } from "vscode-extension-tester";
+import { VSBrowser } from "vscode-extension-tester";
 import { expect } from "chai";
 import * as path from "path";
-import { getStatusBarItem } from "../../test-support/page-objects/cairoStatusBarItem";
+import { getStatusBarItemTitle } from "../../test-support/page-objects/cairoStatusBarItem";
+import { findSetting } from "../../test-support/page-objects/settings";
+import { executeCommand } from "../../test-support/page-objects/workbench";
 import { homedir } from "os";
 
+const TITLE_PATTERN =
+  /Cairo, (Cairo Language Server.+\(.+\))\n\n.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/;
+
 describe("Toolchain info", function () {
-  this.timeout(50000);
+  this.timeout(120000);
 
   it("Checks correct scarb precedence", async function () {
     await VSBrowser.instance.waitForWorkbench();
@@ -32,46 +37,39 @@ describe("Toolchain info", function () {
     }
 
     if (process.env.CONFIG_SCARB_VERSION) {
-      const workbench = new Workbench();
-
-      const settings = await workbench.openSettings();
-
-      const setting = await settings.findSetting("Scarb Path", "Cairo1");
+      const setting = await findSetting("Scarb Path", "Cairo1");
 
       await setting.setValue(path.join(homedir(), ".local", "bin", "scarb"));
 
-      await workbench.executeCommand("Cairo: Reload workspace");
+      await executeCommand("Cairo: Reload workspace");
     }
 
     await VSBrowser.instance.waitForWorkbench();
     await VSBrowser.instance.openResources(path.join("ui-test", "fixtures", "empty"));
 
     await VSBrowser.instance.waitForWorkbench();
-    const statusBar = await VSBrowser.instance.driver.wait(getStatusBarItem, 15000);
 
-    expect(statusBar).to.not.be.undefined;
-
-    const title = await statusBar!.getAttribute(StatusBar["locators"].StatusBar.itemTitle);
-
-    expect(title).to.match(
-      /Cairo, (Cairo Language Server.+\(.+\))\n\n.+\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/,
+    // The title shows toolchain info only after the language server starts (and after
+    // the workspace reload takes effect), so poll until the expected version appears.
+    const title = await getStatusBarItemTitle(
+      (title) => extractScarbVersion(title) === expectedScarbVersion,
+      60000,
     );
 
-    const matches =
-      /Cairo, (?:Cairo Language Server.+\(.+\))\n\nscarb(.+)\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/.exec(
-        title,
-      );
-
-    expect(matches).to.not.be.undefined;
-    expect(matches).to.not.be.null;
-    expect(matches![1]).to.not.be.undefined;
-    expect(matches![1]).to.not.be.null;
-
-    const scarbVersion = matches![1]!.replaceAll("&nbsp;", "").replaceAll("\\", "");
-
-    expect(scarbVersion).to.be.eq(expectedScarbVersion);
+    expect(title).to.not.be.undefined;
+    expect(title!).to.match(TITLE_PATTERN);
+    expect(extractScarbVersion(title!)).to.be.eq(expectedScarbVersion);
   });
 });
+
+function extractScarbVersion(title: string): string | undefined {
+  const matches =
+    /Cairo, (?:Cairo Language Server.+\(.+\))\n\nscarb(.+)\(.+\)\n\ncairo:.+\(.+\)\n\nsierra:.+\n/.exec(
+      title,
+    );
+
+  return matches?.[1]?.replaceAll("&nbsp;", "").replaceAll("\\", "");
+}
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace


### PR DESCRIPTION
 The e2e tests were flaky because they read UI state exactly once at moments when VS Code populates it asynchronously — every retrievable e2e failure on CI was the same crash: TypeError: Cannot read properties of undefined (reading 'setValue') in the "Checks correct scarb precedence" test.

Root causes found

1. SettingsEditor.findSetting is racy (the dominant CI failure): it types into the settings search box and scans only the currently-rendered rows of the virtualized list, returning undefined when the results haven't settled. Both toolchainInfo.ts and statusBar.ts called .setValue() on that result immediately.
2. The status-bar tooltip is populated asynchronously by the language server (and updated again after "Reload workspace"), but tests read the title once and asserted on it — a race with server startup.
3. Workbench.executeCommand types into the command palette before it's interactable when focus is trapped in a settings input — I reproduced this locally as an ElementNotInteractableError right after setting the scarb path.

Changes (on maciektr/e2e, uncommitted)

- test-support/page-objects/settings.ts (new) — findSetting(title, category) that retries the whole open-settings → search sequence for up to 30s instead of one shot.
- test-support/page-objects/workbench.ts (new) — executeCommand(command) that retries the palette interaction.
- test-support/page-objects/cairoStatusBarItem.ts — added getStatusBarItemTitle(isExpected, timeout), which polls until the title matches the expectation and returns the last observed title on timeout so assertions still produce a readable diff (also tolerates stale-element re-renders).
- ui-test/scarb/toolchainInfo.ts and ui-test/generic/statusBar.ts — rewired to use the helpers; the version assertions now poll until the expected scarb version appears (absorbing the reload-workspace transition) rather than asserting on a single read; bumped suite timeouts to 120s to accommodate the retries.
